### PR TITLE
Assume hermiticity by default in TDVP

### DIFF
--- a/src/bondgate.jl
+++ b/src/bondgate.jl
@@ -21,7 +21,8 @@ bond(G::BondGate) = G.b
 
 const GateList = Vector{BondGate}
 
-exp(G::BondGate; hermitian=false) = BondGate( exp(G.G, findprimeinds(G.G), findprimeinds(G.G,0); ishermitian=hermitian), G.b)
+exp(G::BondGate; ishermitian=false) = BondGate(exp(G.G, findprimeinds(G.G), findprimeinds(G.G,0);
+                                                    ishermitian=ishermitian), G.b)
 
 """
     apply_gate!(psi::MPS,G::BondGate ; kwargs...)
@@ -40,7 +41,7 @@ The important ones are:
     value specified by `cutoff`.
 - `cutoff::Float`: If specified, keep the minimal number of singular-values such that the discarded weight is
     smaller than `cutoff` (but bond dimension will be kept smaller than `maxdim`).
-- `absoluteCutoff::Bool`: If `true` truncate all singular-values whose square is smaller than `cutoff`.
+- `use_absolute_cutoff::Bool = false`: If `true` truncate all singular-values whose square is smaller than `cutoff`.
 """
 function apply_gate!(psi::MPS,G::BondGate ; kwargs...)
     b = bond(G)

--- a/src/tdvp.jl
+++ b/src/tdvp.jl
@@ -22,7 +22,7 @@ namely:
 - `absoluteCutoff::Bool`: If `true` truncate all singular-values whose square is smaller than `cutoff`.
 
 In addition the following keyword arguments are supported:
-- `hermitian::Bool` (`false`) : whether the MPO `H` represents an Hermitian operator. This will be passed to the
+- `hermitian::Bool` (`true`) : whether the MPO `H` represents an Hermitian operator. This will be passed to the
     Krylov exponentiation routine (`KrylovKit.exponentiate`) which will in turn use a Lancosz algorithm in the
     case of an hermitian operator.
 - `exp_tol::Float` (1e-14) : The error tolerance for `KrylovKit.exponentiate`.
@@ -37,7 +37,7 @@ https://doi.org/10.1103/PhysRevB.94.165116
 function tdvp!(psi,H::MPO,dt,tf; kwargs...)
     nsteps = Int(tf/dt)
     cb = get(kwargs,:callback, NoTEvoCallback())
-    hermitian = get(kwargs,:hermitian,false)
+    hermitian = get(kwargs,:hermitian,true)
     exp_tol = get(kwargs,:exp_tol, 1e-14)
     krylovdim = get(kwargs,:krylovdim, 30 )
     maxiter = get(kwargs,:maxiter,100)

--- a/src/tebd.jl
+++ b/src/tebd.jl
@@ -53,20 +53,20 @@ the ``exp(-iH_o τᵢ/2)`` terms from consecutive Us and time-steps (except at m
 struct TEBD4 <: TEBDalg
 end
 
-function time_evo_gates(dt, H::GateList, alg::TEBD2; ishermitian=true)
+function time_evo_gates(dt, H::GateList, alg::TEBD2; ishermitian=false)
     Uhalf = exp.(-1im*dt/2 .* H[1:2:end]; ishermitian=ishermitian)
     Us = [exp.( -1im*dt .* H[2:2:end]; ishermitian=ishermitian),
           exp.(-1im*dt .* H[1:2:end]; ishermitian=ishermitian)]
     return [Uhalf ], Us, [Us[1], Uhalf]
 end
 
-function time_evo_gates(dt,H::GateList,alg::TEBD2Sweep; ishermitian=ishermitian)
+function time_evo_gates(dt,H::GateList,alg::TEBD2Sweep; ishermitian=false)
     Us = [exp.(-1im*dt/2 .* H, ishermitian=ishermitian),
           exp.(-1im*dt/2 .* H; ishermitian=ishermitian)]
     return [], Us, []
 end
 
-function time_evo_gates(dt,H::GateList,alg::TEBD4; ishermitian=true)
+function time_evo_gates(dt,H::GateList,alg::TEBD4; ishermitian=false)
     τ₁ = 1/(4-4^(1/3))*dt
     τ₂ = τ₁
     τ₃ = dt - 2*τ₁ - 2*τ₂

--- a/src/tebd.jl
+++ b/src/tebd.jl
@@ -53,18 +53,20 @@ the ``exp(-iH_o τᵢ/2)`` terms from consecutive Us and time-steps (except at m
 struct TEBD4 <: TEBDalg
 end
 
-function time_evo_gates(dt, H::GateList, alg::TEBD2)
-    Uhalf = exp.(-1im*dt/2 .* H[1:2:end])
-    Us = [exp.( -1im*dt .* H[2:2:end]), exp.(-1im*dt .* H[1:2:end])]
+function time_evo_gates(dt, H::GateList, alg::TEBD2; ishermitian=true)
+    Uhalf = exp.(-1im*dt/2 .* H[1:2:end]; ishermitian=ishermitian)
+    Us = [exp.( -1im*dt .* H[2:2:end]; ishermitian=ishermitian),
+          exp.(-1im*dt .* H[1:2:end]; ishermitian=ishermitian)]
     return [Uhalf ], Us, [Us[1], Uhalf]
 end
 
-function time_evo_gates(dt,H::GateList,alg::TEBD2Sweep)
-    Us = [exp.(-1im*dt/2 .* H), exp.(-1im*dt/2 .* H)]
+function time_evo_gates(dt,H::GateList,alg::TEBD2Sweep; ishermitian=ishermitian)
+    Us = [exp.(-1im*dt/2 .* H, ishermitian=ishermitian),
+          exp.(-1im*dt/2 .* H; ishermitian=ishermitian)]
     return [], Us, []
 end
 
-function time_evo_gates(dt,H::GateList,alg::TEBD4)
+function time_evo_gates(dt,H::GateList,alg::TEBD4; ishermitian=true)
     τ₁ = 1/(4-4^(1/3))*dt
     τ₂ = τ₁
     τ₃ = dt - 2*τ₁ - 2*τ₂
@@ -75,11 +77,11 @@ function time_evo_gates(dt,H::GateList,alg::TEBD4)
 
     sequence = [(τ₁, e), (τ₁, o ), (τ₂,e), ((τ₂+τ₃)/2, o), (τ₃, e),
                 ((τ₂+τ₃)/2, o), (τ₂,e), (τ₂,o), (τ₁,e), (τ₁,o)]
-    Us = map(x->exp.(-1im*x[1] .* H[x[2]]), sequence)
+    Us = map(x->exp.(-1im*x[1] .* H[x[2]]; ishermitian=ishermitian), sequence)
 
     end_sequence = [(τ₁, e), (τ₁, o ), (τ₂,e), ((τ₂+τ₃)/2, o), (τ₃, e),
                     ((τ₂+τ₃)/2, o), (τ₂,e), (τ₂,o), (τ₁,e), (τ₁/2,o)]
-    Uend = map(x->exp.(-1im*x[1] .* H[x[2]]), end_sequence)
+    Uend = map(x->exp.(-1im*x[1] .* H[x[2]]; ishermitian=ishermitian), end_sequence)
 
     return Ustart, Us , Uend
 end
@@ -90,6 +92,7 @@ function tebd!(psi::MPS, H::GateList, dt::Number, tf::Number, alg::TEBDalg = TEB
     # TODO: think of the best way to avoid inexact error when dt is very small
     # one option would be to use round(tf/dt) and verify that abs(round(tf/dt)-tf/dt)
     # is smaller than some threshold. Another option would be to use big(Rational(dt)).
+    ishermitian = get(kwargs, :ishermitian, dt isa Complex && real(dt)==0)
     nsteps = Int(tf/dt)
     cb = get(kwargs,:callback, NoTEvoCallback())
     cb_func(dt,step,rev,se) = (psi; bond, spec) -> apply!(cb,psi;
@@ -112,7 +115,7 @@ function tebd!(psi::MPS, H::GateList, dt::Number, tf::Number, alg::TEBDalg = TEB
     end
     orthogonalize_step > 0 && (nbunch = gcd(nbunch,orthogonalize_step))
 
-    Ustart, Us, Uend = time_evo_gates(dt,H,alg)
+    Ustart, Us, Uend = time_evo_gates(dt,H,alg; ishermitian=ishermitian)
 
     length(Ustart)==0 && length(Uend)==0 && (nbunch+=1)
 

--- a/src/tebd.jl
+++ b/src/tebd.jl
@@ -92,8 +92,13 @@ function tebd!(psi::MPS, H::GateList, dt::Number, tf::Number, alg::TEBDalg = TEB
     # TODO: think of the best way to avoid inexact error when dt is very small
     # one option would be to use round(tf/dt) and verify that abs(round(tf/dt)-tf/dt)
     # is smaller than some threshold. Another option would be to use big(Rational(dt)).
-    ishermitian = get(kwargs, :ishermitian, dt isa Complex && real(dt)==0)
     nsteps = Int(tf/dt)
+
+    # TODO: use ishermitian for imaginary time-evolution once exponentiation
+    # of hermitian ITensor is fixed (see https://github.com/ITensor/NDTensors.jl/pull/15).
+    # ishermitian = get(kwargs, :ishermitian, dt isa Complex && real(dt)==0)
+    ishermitian = get(kwargs, :ishermitian, false)
+
     cb = get(kwargs,:callback, NoTEvoCallback())
     cb_func(dt,step,rev,se) = (psi; bond, spec) -> apply!(cb,psi;
                                                               t=dt*step,


### PR DESCRIPTION
This is better because the most typical use case would be with hermitian Hamiltonians. 
In the case of non-hermitian evolution one would have to specify `hermitian=false`. 